### PR TITLE
Add requirements.txt of python library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+geopy==1.11.0
+protobuf==2.6.1
+requests==2.10.0


### PR DESCRIPTION
There is no `requirements` file. So I Added.

And should update readme.md to know way installing protobuf of google on Windows, Mac and Linux.
