### PR TITLE
added setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from pip.req import parse_requirements
+
+install_reqs = parse_requirements("requirements.txt", session=False)
+
+reqs = [str(ir.req) for ir in install_reqs]
+
+setup(name='pgoapi',
+      version='1.0',
+      url='https://github.com/tejado/pgoapi',
+      packages=['pgoapi'],
+      install_requires=reqs
+     )


### PR DESCRIPTION
with setup.py it's possible for other projects to refer to this one. For example it's possible to have an requirements.txt with:

```
-e git://github.com/tejado/pgoapi.git@9c11277#egg=pgoapi
```

after that it can be used:

``` python
from pgoapi import PGoApi
```

hopefully that'll bring some sanity to copying .proto and _pb2.py files to all the pgo repos.

Also, it'll make a start with versioning. this sets the version to 1.0, so it might be an idea to tag it 1.0 as well.
