### PR TITLE
Add timeout to API call

### DIFF
--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -51,9 +51,18 @@ class AuthPtc(Auth):
         self.log.info('Login for: %s', username)
         
         head = {'User-Agent': 'niantic'}
-        r = self._session.get(self.PTC_LOGIN_URL, headers=head, timeout=10)
+        try:
+            r = self._session.get(self.PTC_LOGIN_URL, headers=head, timeout=10)
+        except requests.exceptions.ReadTimeout:
+            self.log.error('Server timed out')
+            return False
         
-        jdata = json.loads(r.content.decode('utf-8'))
+        try:
+            jdata = json.loads(r.content.decode('utf-8'))
+        except ValueError:
+            self.log.error('Could not decode response')
+            return False
+            
         data = {
             'lt': jdata['lt'],
             'execution': jdata['execution'],
@@ -61,7 +70,11 @@ class AuthPtc(Auth):
             'username': username,
             'password': password,
         }
-        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head, timeout=10)
+        try:
+            r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head, timeout=10)
+        except requests.exceptions.ReadTimeout:
+            self.log.error('Server timed out')
+            return False
 
         ticket = None
         try:
@@ -81,7 +94,11 @@ class AuthPtc(Auth):
             'code': ticket,
         }
         
-        r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1, timeout=10)
+        try:
+            r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1, timeout=10)
+        except requests.exceptions.ReadTimeout:
+            self.log.error('Server timed out')
+            return False
         access_token = re.sub('&expires.*', '', r2.content.decode('utf-8'))
         access_token = re.sub('.*access_token=', '', access_token)
 

--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -51,7 +51,7 @@ class AuthPtc(Auth):
         self.log.info('Login for: %s', username)
         
         head = {'User-Agent': 'niantic'}
-        r = self._session.get(self.PTC_LOGIN_URL, headers=head, requests=10)
+        r = self._session.get(self.PTC_LOGIN_URL, headers=head, timeout=10)
         
         jdata = json.loads(r.content.decode('utf-8'))
         data = {
@@ -61,7 +61,7 @@ class AuthPtc(Auth):
             'username': username,
             'password': password,
         }
-        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head, requests=10)
+        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head, timeout=10)
 
         ticket = None
         try:
@@ -81,7 +81,7 @@ class AuthPtc(Auth):
             'code': ticket,
         }
         
-        r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1, requests=10)
+        r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1, timeout=10)
         access_token = re.sub('&expires.*', '', r2.content.decode('utf-8'))
         access_token = re.sub('.*access_token=', '', access_token)
 

--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -51,7 +51,7 @@ class AuthPtc(Auth):
         self.log.info('Login for: %s', username)
         
         head = {'User-Agent': 'niantic'}
-        r = self._session.get(self.PTC_LOGIN_URL, headers=head)
+        r = self._session.get(self.PTC_LOGIN_URL, headers=head, requests=10)
         
         jdata = json.loads(r.content.decode('utf-8'))
         data = {
@@ -61,7 +61,7 @@ class AuthPtc(Auth):
             'username': username,
             'password': password,
         }
-        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head)
+        r1 = self._session.post(self.PTC_LOGIN_URL, data=data, headers=head, requests=10)
 
         ticket = None
         try:
@@ -81,7 +81,7 @@ class AuthPtc(Auth):
             'code': ticket,
         }
         
-        r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1)
+        r2 = self._session.post(self.PTC_LOGIN_OAUTH, data=data1, requests=10)
         access_token = re.sub('&expires.*', '', r2.content.decode('utf-8'))
         access_token = re.sub('.*access_token=', '', access_token)
 

--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -76,7 +76,7 @@ class RpcApi:
         
         request_proto_serialized = request_proto_plain.SerializeToString()
         try:
-            http_response = self._session.post(endpoint, data=request_proto_serialized)
+            http_response = self._session.post(endpoint, data=request_proto_serialized, timeout=10)
         except requests.exceptions.ConnectionError as e:
             raise ServerBusyOrOfflineException
         


### PR DESCRIPTION
When logging in, the niantic server sometimes doesn't respond at all. Which will cause any tool using this API to hang forever (my server hung overnight for hours). 
The requests library by default has not timeout value, so we need to set it manually.
