### PR TITLE
Fix empty loc returns on get_pos_by_name()

### DIFF
--- a/examples/pogo-optimizer/pogo-optimizer-cli.py
+++ b/examples/pogo-optimizer/pogo-optimizer-cli.py
@@ -56,6 +56,8 @@ log = logging.getLogger(__name__)
 def get_pos_by_name(location_name):
     geolocator = GoogleV3()
     loc = geolocator.geocode(location_name, timeout=10)
+    if not loc:
+        return None
 
     log.info('Your given location: %s', loc.address.encode('utf-8'))
     log.info('lat/long/alt: %s %s %s', loc.latitude, loc.longitude, loc.altitude)
@@ -142,6 +144,9 @@ def main():
         logging.getLogger("rpc_api").setLevel(logging.DEBUG)
     
     position = get_pos_by_name(config.location)
+    if not position:
+        return
+        
     if config.test:
         return
     

--- a/examples/spiral_poi_search.py
+++ b/examples/spiral_poi_search.py
@@ -49,6 +49,8 @@ log = logging.getLogger(__name__)
 def get_pos_by_name(location_name):
     geolocator = GoogleV3()
     loc = geolocator.geocode(location_name)
+    if not loc:
+        return None
 
     log.info('Your given location: %s', loc.address.encode('utf-8'))
     log.info('lat/long/alt: %s %s %s', loc.latitude, loc.longitude, loc.altitude)
@@ -130,6 +132,9 @@ def main():
         logging.getLogger("rpc_api").setLevel(logging.DEBUG)
 
     position = get_pos_by_name(config.location)
+    if not position:
+        return
+        
     if config.test:
         return
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -54,7 +54,8 @@ log = logging.getLogger(__name__)
 def get_pos_by_name(location_name):
     geolocator = GoogleV3()
     loc = geolocator.geocode(location_name, timeout=10)
-
+    if not loc:
+        return None
     log.info('Your given location: %s', loc.address.encode('utf-8'))
     log.info('lat/long/alt: %s %s %s', loc.latitude, loc.longitude, loc.altitude)
 
@@ -140,6 +141,9 @@ def main():
         logging.getLogger("rpc_api").setLevel(logging.DEBUG)
 
     position = get_pos_by_name(config.location)
+    if not position:
+        return
+        
     if config.test:
         return
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -142,6 +142,7 @@ def main():
 
     position = get_pos_by_name(config.location)
     if not position:
+        log.error('Position could not be found by name')
         return
         
     if config.test:


### PR DESCRIPTION
If geolocator.geocode() doesn’t find a location by name loc is going to be
None and this breaks loc.latitude, etc.
