### PR TITLE
Fix unicode username/password for python2

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 import logging
 import re
 import requests
+import six
 
 from .utilities import f2i, h2f
 from pgoapi.rpc_api import RpcApi
@@ -45,71 +46,71 @@ class PGoApi:
     API_ENTRY = 'https://pgorelease.nianticlabs.com/plfe/rpc'
 
     def __init__(self):
-    
+
         self.log = logging.getLogger(__name__)
 
         self._auth_provider = None
         self._api_endpoint = None
-        
+
         self._position_lat = 0
         self._position_lng = 0
         self._position_alt = 0
 
         self._req_method_list = []
-        
+
     def call(self):
         if not self._req_method_list:
             return False
-        
+
         if self._auth_provider is None or not self._auth_provider.is_login():
             self.log.info('Not logged in')
             return False
-        
+
         player_position = self.get_position()
-        
+
         request = RpcApi(self._auth_provider)
-        
+
         if self._api_endpoint:
             api_endpoint = self._api_endpoint
         else:
             api_endpoint = self.API_ENTRY
-        
+
         self.log.info('Execution of RPC')
         response = None
         try:
             response = request.request(api_endpoint, self._req_method_list, player_position)
         except ServerBusyOrOfflineException as e:
             self.log.info('Server seems to be busy or offline - try again!')
-        
+
         # cleanup after call execution
         self.log.info('Cleanup of request!')
         self._req_method_list = []
-        
+
         return response
 
     def list_curr_methods(self):
         for i in self._req_method_list:
             print("{} ({})".format(RequestType.Name(i),i))
-    
+
     def set_logger(self, logger):
         self._ = logger or logging.getLogger(__name__)
 
     def get_position(self):
         return (self._position_lat, self._position_lng, self._position_alt)
 
-    def set_position(self, lat, lng, alt):   
+    def set_position(self, lat, lng, alt):
         self.log.debug('Set Position - Lat: %s Long: %s Alt: %s', lat, lng, alt)
-        
+
         self._position_lat = f2i(lat)
         self._position_lng = f2i(lng)
         self._position_alt = f2i(alt)
 
     def __getattr__(self, func):
         def function(**kwargs):
-        
+
             if not self._req_method_list:
                 self.log.info('Create new request...')
-        
+
             name = func.upper()
             if kwargs:
                 self._req_method_list.append( { RequestType.Value(name): kwargs } )
@@ -118,60 +119,59 @@ class PGoApi:
             else:
                 self._req_method_list.append( RequestType.Value(name) )
                 self.log.info("Adding '%s' to RPC request", name)
-   
+
             return self
-   
+
         if func.upper() in RequestType.keys():
             return function
         else:
             raise AttributeError
-            
-        
+
+
     def login(self, provider, username, password):
-    
-        if not isinstance(username, str) or not isinstance(password, str):
+
+        if not isinstance(username, six.string_types) or not isinstance(password, six.string_types):
             raise AuthException("Username/password not correctly specified")
-        
+
         if provider == 'ptc':
             self._auth_provider = AuthPtc()
         elif provider == 'google':
             self._auth_provider = AuthGoogle()
         else:
             raise AuthException("Invalid authentication provider - only ptc/google available.")
-            
+
         self.log.debug('Auth provider: %s', provider)
-        
+
         if not self._auth_provider.login(username, password):
-            self.log.info('Login process failed') 
+            self.log.info('Login process failed')
             return False
-        
+
         self.log.info('Starting RPC login sequence (app simulation)')
-        
+
         # making a standard call, like it is also done by the client
         self.get_player()
         self.get_hatched_eggs()
         self.get_inventory()
         self.check_awarded_badges()
         self.download_settings(hash="05daf51635c82611d1aac95c0b051d3ec088a930")
-        
+
         response = self.call()
-        
-        if not response: 
-            self.log.info('Login failed!') 
+
+        if not response:
+            self.log.info('Login failed!')
             return False
-        
+
         if 'api_url' in response:
             self._api_endpoint = ('https://{}/rpc'.format(response['api_url']))
             self.log.debug('Setting API endpoint to: %s', self._api_endpoint)
         else:
             self.log.error('Login failed - unexpected server response!')
             return False
-        
+
         if 'auth_ticket' in response:
             self._auth_provider.set_ticket(response['auth_ticket'].values())
-        
+
         self.log.info('Finished RPC login sequence (app simulation)')
-        self.log.info('Login process completed') 
-        
+        self.log.info('Login process completed')
+
         return True
-        

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ protobuf>=3.0.0a3
 requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.3.0
+six


### PR DESCRIPTION
`isinstance(val, str)` is only python3 unicode safe

Since `six` is already required from protobuf, I just added an explicit requirement for it, and check `isinstance(val, six.string_types)` instead, which evaluates to `(str, unicode)` for python2, and `(str,)` for python3

Protobuf does the same isinstance checks internally
