### PR TITLE
Add missing import

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -30,6 +30,8 @@ import logging
 import requests
 import subprocess
 
+from google.protobuf import message
+
 from importlib import import_module
 
 from pgoapi.protobuf_to_dict import protobuf_to_dict
@@ -192,7 +194,7 @@ class RpcApi:
         response_proto = ResponseEnvelope()
         try:
             response_proto.ParseFromString(response_raw.content)
-        except google.protobuf.message.DecodeError as e:
+        except message.DecodeError as e:
             self.log.warning('Could not parse response: %s', str(e))
             return False
         


### PR DESCRIPTION
Seems like google module was not imported to handle google.protobuf.message.DecodeError, so import message from google.protobuf and handle message.DecodeError. 
