### PR TITLE
Updated spiral_poi_search.py to conform to PEP 8

### DIFF
--- a/examples/spiral_poi_search.py
+++ b/examples/spiral_poi_search.py
@@ -89,7 +89,7 @@ def init_config():
             load.update(json.load(data))
 
     # Read passed in Arguments
-    required = lambda x: not x in load
+    required = lambda x: x not in load
     parser.add_argument("-a", "--auth_service", help="Auth Service ('ptc' or 'google')",
         required=required("auth_service"))
     parser.add_argument("-u", "--username", help="Username", required=required("username"))


### PR DESCRIPTION
PEP008 is your friend ^^
I inserted a few newlines, and changed `not x in load` to `x not in load`, but if the intended effect was `(not x) in load`, that should be changed accordingly.
- CodenameLambda
