### PR TITLE
Passing objects as API parameter

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -155,6 +155,13 @@ class RpcApi:
                                 r.append(i)
                             except Exception as e:
                                 self.log.warning('Argument %s with value %s unknown inside %s (Exception: %s)', key, i, proto_name, str(e))
+                    elif isinstance(value, dict):
+                        for k in value.keys():
+                            try:
+                                r = getattr(subrequest_extension, key)
+                                setattr(r, k, value[k])
+                            except Exception as e:
+                                self.log.warning('Argument %s with value %s unknown inside %s (Exception: %s)', key, str(value), proto_name, str(e))
                     else:
                         try:
                             setattr(subrequest_extension, key, value)


### PR DESCRIPTION
- Added support to passing object (with python's dict type) as API parameter
- Useful for API such as SetAvatar which takes a PlayerAvatar object as its parameter 'player_avatar'
