### PR TITLE
Add certificate for auth and RPC calls.

### DIFF
--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -46,12 +46,12 @@ class AuthPtc(Auth):
         self._session = requests.session()
         self._session.verify = True
 
-    def login(self, username, password):
+    def login(self, username, password, cert):
 
         self.log.info('Login for: %s', username)
         
         head = {'User-Agent': 'niantic'}
-        r = self._session.get(self.PTC_LOGIN_URL, headers=head)
+        r = self._session.get(self.PTC_LOGIN_URL, headers=head, verify=cert)
 
         try:
             jdata = json.loads(r.content.decode('utf-8'))

--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -49,7 +49,7 @@ class RpcApi:
 
     RPC_ID = 0
 
-    def __init__(self, auth_provider):
+    def __init__(self, auth_provider, certificate):
 
         self.log = logging.getLogger(__name__)
 
@@ -58,6 +58,7 @@ class RpcApi:
         self._session.verify = True
 
         self._auth_provider = auth_provider
+        self._certificate = certificate
 
         if RpcApi.RPC_ID == 0:
             RpcApi.RPC_ID = int(random.random() * 10 ** 18)
@@ -89,7 +90,7 @@ class RpcApi:
 
         request_proto_serialized = request_proto_plain.SerializeToString()
         try:
-            http_response = self._session.post(endpoint, data=request_proto_serialized)
+            http_response = self._session.post(endpoint, data=request_proto_serialized, verify=self._certificate)
         except requests.exceptions.ConnectionError as e:
             raise ServerBusyOrOfflineException
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -62,6 +62,7 @@ def init_config():
     parser.add_argument("-l", "--location", help="Location", required=required("location"))
     parser.add_argument("-d", "--debug", help="Debug Mode", action='store_true')
     parser.add_argument("-t", "--test", help="Only parse the specified location", action='store_true')
+    parser.add_argument("-c", "--cert", help="Certificate")
     parser.set_defaults(DEBUG=False, TEST=False)
     config = parser.parse_args()
 
@@ -116,7 +117,7 @@ def main():
     # set player position on the earth
     api.set_position(*position)
 
-    if not api.login(config.auth_service, config.username, config.password, app_simulation = True):
+    if not api.login(config.auth_service, config.username, config.password, app_simulation = True, cert = config.cert):
         return
 
     # get player profile call (single command example)


### PR DESCRIPTION
For my usage I want to log all HTTP calls. This is only possible with a SSL-man-in-the-middle tool (like [CharlesProxy](https://www.charlesproxy.com/)).

For this reason I need to log all calls with my own SSL cert to:
- sso.pokemon.com
- pgorelease.nianticlabs.com

This commit allows to add a **cert** attribute to _config.json_:

``` json
{
   "cert": "PathToCert"
}
```

For more infos: [StackOverflow - check Python requests with charles proxy for HTTPS](http://stackoverflow.com/a/35192365/2220237).
