### PR TITLE
Utilities: don't geolocate if coordinates were given

### DIFF
--- a/pgoapi/utilities.py
+++ b/pgoapi/utilities.py
@@ -55,15 +55,22 @@ class JSONByteEncoder(JSONEncoder):
         return o.decode('utf-8')
 
 def get_pos_by_name(location_name):
-    geolocator = GoogleV3()
-    loc = geolocator.geocode(location_name, timeout=10)
-    if not loc:
-        return None
+    prog = re.compile("^(\-?\d+\.\d+)?,\s*(\-?\d+\.\d+?)$")
+    res = prog.match(location_name)
+    latitude, longitude, altitude = None, None, None
+    if res:
+        latitude, longitude, altitude = float(res.group(1)), float(res.group(2)), 0
+    else:
+        geolocator = GoogleV3()
+        loc = geolocator.geocode(location_name, timeout=10)
+        if loc:
+            log.info("Location for '%s' found: %s", location_name, loc.address)
+            log.info('Coordinates (lat/long/alt) for location: %s %s %s', loc.latitude, loc.longitude, loc.altitude)
+            latitude, longitude, altitude = loc.latitude, loc.longitude, loc.altitude
+        else:
+            return None
 
-    log.info("Location for '%s' found: %s", location_name, loc.address)
-    log.info('Coordinates (lat/long/alt) for location: %s %s %s', loc.latitude, loc.longitude, loc.altitude)
-
-    return (loc.latitude, loc.longitude, loc.altitude)
+    return (latitude, longitude, altitude)
 
 EARTH_RADIUS = 6371 * 1000
 def get_cell_ids(lat, long, radius=1000):


### PR DESCRIPTION
- If coordinates were given, we can assume the user has already
  geolocated exactly where they want to be scanning. In this case
  don't run it through Google's geolocator which can end up moving
  the location slightly.
