### PR TITLE
Allow logging in without setting a position

### DIFF
--- a/pgoapi/exceptions.py
+++ b/pgoapi/exceptions.py
@@ -35,9 +35,6 @@ class ServerBusyOrOfflineException(Exception):
 class PleaseInstallProtobufVersion3(Exception):
     pass
 
-class NoPlayerPositionSetException(Exception):
-    pass
-    
 class EmptySubrequestChainException(Exception):
     pass
     

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -168,7 +168,7 @@ class PGoApiRequest:
             raise EmptySubrequestChainException()
             
         if (self._position_lat is None) or (self._position_lng is None) or (self._position_alt is None):
-            raise NoPlayerPositionSetException()
+            self.log.info('No player position set')
 
         if self._auth_provider is None or not self._auth_provider.is_login():
             self.log.info('Not logged in')

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -34,7 +34,7 @@ from . import __title__, __version__, __copyright__
 from pgoapi.rpc_api import RpcApi
 from pgoapi.auth_ptc import AuthPtc
 from pgoapi.auth_google import AuthGoogle
-from pgoapi.exceptions import AuthException, NotLoggedInException, ServerBusyOrOfflineException, NoPlayerPositionSetException, EmptySubrequestChainException
+from pgoapi.exceptions import AuthException, NotLoggedInException, ServerBusyOrOfflineException, EmptySubrequestChainException
 
 from . import protos
 from POGOProtos.Networking.Requests_pb2 import RequestType


### PR DESCRIPTION
This is equivalent to logging in using the official game client while the “GPS signal not found” message displays.

See https://github.com/tejado/pgoapi/pull/142#issuecomment-238195792.
